### PR TITLE
Allow "asterisk" and "star" marker to be shown when marker_face_color is set

### DIFF
--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -257,7 +257,7 @@ def _mpl_marker2pgfp_marker(data, mpl_marker, marker_face_color):
                 not isinstance(marker_face_color, str)
                 or marker_face_color.lower() != "none"
             )
-            and pgfplots_marker not in ["|", "-"]
+            and pgfplots_marker not in ["|", "-", "asterisk", "star"]
         ):
             pgfplots_marker += "*"
         return (data, pgfplots_marker, marker_options)


### PR DESCRIPTION
Add marker "asterisk" and "star" to list of markers (in line2d.py), which do not take an optional * for a filled version in pgfplots. With * they are not being shown in pgfplots. 

This change solves this issue: https://github.com/nschloe/matplotlib2tikz/issues/151#issue-217858277 .